### PR TITLE
Add ARM recursion/function examples

### DIFF
--- a/arm/ackermann.s
+++ b/arm/ackermann.s
@@ -1,0 +1,38 @@
+// Jacob Panov
+
+// Computes the Ackermann function recursively.
+// ackermann(m, n)
+
+.global _start
+_start:
+    mov r0, #2
+    mov r1, #2
+    bl ackermann
+    1: b 1b
+
+.global ackermann
+ackermann:
+    push {r4-r5, lr}
+    cmp r0, #0
+    bne m_not_zero
+    add r0, r1, #1
+    pop {r4-r5, lr}
+    bx lr
+m_not_zero:
+    cmp r1, #0
+    bne rec_case
+    sub r0, r0, #1
+    mov r1, #1
+    bl ackermann
+    pop {r4-r5, lr}
+    bx lr
+rec_case:
+    mov r4, r0
+    mov r5, r1
+    sub r1, r1, #1
+    bl ackermann
+    mov r1, r0
+    sub r0, r4, #1
+    bl ackermann
+    pop {r4-r5, lr}
+    bx lr

--- a/arm/callparam.s
+++ b/arm/callparam.s
@@ -1,0 +1,22 @@
+// Jacob Panov
+
+// Demonstrates passing parameters to a function. The function
+// sum4 adds four 32-bit integers passed in r0-r3 and returns
+// the result in r0.
+
+.global _start
+_start:
+    mov r0, #1
+    mov r1, #2
+    mov r2, #3
+    mov r3, #4
+    bl sum4
+    1: b 1b
+
+.global sum4
+sum4:
+    // r0=r0, r1=r1, r2=r2, r3=r3
+    add r0, r0, r1
+    add r0, r0, r2
+    add r0, r0, r3
+    bx lr

--- a/arm/callsave.s
+++ b/arm/callsave.s
@@ -1,0 +1,18 @@
+// Jacob Panov
+
+// Demonstrates preserving callee-saved registers in a function.
+// times10 multiplies its argument by 10 and returns the result.
+
+.global _start
+_start:
+    mov r0, #5
+    bl times10
+    1: b 1b
+
+.global times10
+times10:
+    push {r4, lr}
+    mov r4, #10
+    mul r0, r4, r0
+    pop {r4, lr}
+    bx lr

--- a/arm/fib1.s
+++ b/arm/fib1.s
@@ -1,0 +1,27 @@
+// Jacob Panov
+
+// Recursive Fibonacci implementation.
+
+.global _start
+_start:
+    mov r0, #10
+    bl fib1
+    1: b 1b
+
+.global fib1
+fib1:
+    push {r4-r5, lr}
+    cmp r0, #1
+    ble base
+    mov r4, r0          // save n
+    sub r0, r0, #1
+    bl fib1             // fib(n-1)
+    mov r5, r0          // save result
+    sub r0, r4, #2
+    bl fib1             // fib(n-2)
+    add r0, r0, r5
+    pop {r4-r5, lr}
+    bx lr
+base:
+    pop {r4-r5, lr}
+    bx lr

--- a/arm/fib2.s
+++ b/arm/fib2.s
@@ -1,0 +1,32 @@
+// Jacob Panov
+
+// Iterative Fibonacci calculation.
+
+.global _start
+_start:
+    mov r0, #10
+    bl fib2
+    1: b 1b
+
+.global fib2
+fib2:
+    push {r4-r6, lr}
+    cmp r0, #1
+    ble base
+    mov r4, #0  // a = fib(0)
+    mov r5, #1  // b = fib(1)
+loop:
+    subs r0, r0, #1
+    beq done
+    add r6, r4, r5
+    mov r4, r5
+    mov r5, r6
+    b loop
+
+done:
+    mov r0, r5
+    pop {r4-r6, lr}
+    bx lr
+base:
+    pop {r4-r6, lr}
+    bx lr

--- a/arm/func_pack20.s
+++ b/arm/func_pack20.s
@@ -1,0 +1,44 @@
+// Jacob Panov
+
+// Demonstrates calling another function multiple times.
+// pack20 reads 20 groups of three bytes from Src and stores packed
+// words to Dst using pack3.
+
+.data
+Src:
+    .byte 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60
+Dst:
+    .space 20*4
+
+.text
+.global _start
+_start:
+    ldr r0, =Src
+    ldr r1, =Dst
+    bl pack20
+    1: b 1b
+
+.global pack20
+pack20:
+    push {r4-r6, lr}
+    mov r4, r0        // src
+    mov r5, r1        // dst
+    mov r6, #20
+loop:
+    ldrb r0, [r4], #1
+    ldrb r1, [r4], #1
+    ldrb r2, [r4], #1
+    bl pack3
+    str r0, [r5], #4
+    subs r6, r6, #1
+    bne loop
+    pop {r4-r6, lr}
+    bx lr
+
+// pack3 as defined earlier
+.global pack3
+pack3:
+    lsl r0, r0, #16
+    orr r0, r0, r1, lsl #8
+    orr r0, r0, r2
+    bx lr

--- a/arm/func_pack3.s
+++ b/arm/func_pack3.s
@@ -1,0 +1,20 @@
+// Jacob Panov
+
+// pack3 packs three bytes into a 32-bit word as
+// (a << 16) | (b << 8) | c.
+
+.global _start
+_start:
+    mov r0, #0x12
+    mov r1, #0x34
+    mov r2, #0x56
+    bl pack3
+    1: b 1b
+
+.global pack3
+pack3:
+    // r0=a, r1=b, r2=c
+    lsl r0, r0, #16
+    orr r0, r0, r1, lsl #8
+    orr r0, r0, r2
+    bx lr

--- a/arm/max_args.s
+++ b/arm/max_args.s
@@ -1,0 +1,33 @@
+// Jacob Panov
+
+// Returns the maximum value in an array.
+
+.data
+Vals: .word 3,1,5,2,4
+
+.text
+.global _start
+_start:
+    ldr r0, =Vals
+    mov r1, #5
+    bl max_args
+    1: b 1b
+
+.global max_args
+max_args:
+    push {r4, lr}
+    ldr r4, [r0], #4
+    subs r1, r1, #1
+loop:
+    cmp r1, #0
+    beq done
+    ldr r2, [r0], #4
+    cmp r2, r4
+    movgt r4, r2
+    subs r1, r1, #1
+    bne loop
+
+done:
+    mov r0, r4
+    pop {r4, lr}
+    bx lr

--- a/arm/sum_args.s
+++ b/arm/sum_args.s
@@ -1,0 +1,32 @@
+// Jacob Panov
+
+// sum_args sums an array of integers passed by pointer and count.
+
+.data
+Numbers: .word 1,2,3,4
+
+.text
+.global _start
+_start:
+    ldr r0, =Numbers
+    mov r1, #4
+    bl sum_args
+    1: b 1b
+
+.global sum_args
+sum_args:
+    // r0 = pointer, r1 = count
+    push {r4, lr}
+    mov r4, #0
+loop:
+    cmp r1, #0
+    beq done
+    ldr r2, [r0], #4
+    add r4, r4, r2
+    subs r1, r1, #1
+    bne loop
+
+done:
+    mov r0, r4
+    pop {r4, lr}
+    bx lr

--- a/arm/sum_args20.s
+++ b/arm/sum_args20.s
@@ -1,0 +1,33 @@
+// Jacob Panov
+
+// Sums 20 integers stored in an array.
+
+.data
+Nums20:
+    .word 1,2,3,4,5,6,7,8,9,10
+    .word 11,12,13,14,15,16,17,18,19,20
+
+.text
+.global _start
+_start:
+    ldr r0, =Nums20
+    mov r1, #20
+    bl sum_args20
+    1: b 1b
+
+.global sum_args20
+sum_args20:
+    push {r4, lr}
+    mov r4, #0
+loop:
+    cmp r1, #0
+    beq done
+    ldr r2, [r0], #4
+    add r4, r4, r2
+    subs r1, r1, #1
+    bne loop
+
+done:
+    mov r0, r4
+    pop {r4, lr}
+    bx lr

--- a/arm/treedepth.s
+++ b/arm/treedepth.s
@@ -1,0 +1,53 @@
+// Jacob Panov
+
+// Returns whether a tree's depth is at most a given bound.
+// Prototype: treedepth(root, depth)
+// Node layout: [left, right]; null pointer = 0.
+
+.data
+node_l: .word 0,0
+node_r: .word 0,0
+root_n: .word node_l, node_r
+
+.text
+.global _start
+_start:
+    ldr r0, =root_n
+    mov r1, #2
+    bl treedepth
+    1: b 1b
+
+.global treedepth
+treedepth:
+    push {r4-r7, lr}
+    cmp r0, #0
+    beq return_true
+    cmp r1, #0
+    beq return_false
+    ldr r4, [r0]
+    ldr r5, [r0, #4]
+    sub r1, r1, #1
+    mov r0, r4
+    mov r6, r5
+    mov r7, r1
+    bl treedepth
+    cmp r0, #0
+    beq done_false
+    mov r0, r6
+    mov r1, r7
+    bl treedepth
+    cmp r0, #0
+    beq done_false
+    mov r0, #1
+    b done
+return_true:
+    mov r0, #1
+    b done
+return_false:
+    mov r0, #0
+    b done
+done_false:
+    mov r0, #0
+done:
+    pop {r4-r7, lr}
+    bx lr

--- a/arm/treesize.s
+++ b/arm/treesize.s
@@ -1,0 +1,37 @@
+// Jacob Panov
+
+// Recursively computes the number of nodes in a binary tree.
+// Node layout: [left, right]; null pointer = 0.
+
+.data
+node_left:  .word 0, 0
+node_right: .word 0, 0
+root_node:  .word node_left, node_right
+
+.text
+.global _start
+_start:
+    ldr r0, =root_node
+    bl treesize
+    1: b 1b
+
+.global treesize
+treesize:
+    push {r4-r6, lr}
+    cmp r0, #0
+    beq zero
+    ldr r4, [r0]
+    ldr r5, [r0, #4]
+    mov r0, r4
+    bl treesize
+    mov r6, r0
+    mov r0, r5
+    bl treesize
+    add r0, r0, r6
+    add r0, r0, #1
+    pop {r4-r6, lr}
+    bx lr
+zero:
+    mov r0, #0
+    pop {r4-r6, lr}
+    bx lr


### PR DESCRIPTION
## Summary
- add examples for function calls and recursion
- implement sample Fibonacci, tree and Ackermann routines
- demonstrate callee-saved registers and parameter passing
- fix multiply instruction and pack3 routine
- rename `timesTen` to `times10`
- correct `treesize` recursion logic and update `treedepth` to check depth limit

## Testing
- `arm-linux-gnueabi-as --version | head -n 1`
- `for f in arm/ackermann.s arm/callparam.s arm/callsave.s arm/fib1.s arm/fib2.s arm/func_pack20.s arm/func_pack3.s arm/max_args.s arm/sum_args.s arm/sum_args20.s arm/treedepth.s arm/treesize.s; do arm-linux-gnueabi-as $f -o /tmp/$(basename $f .s).o; done`

------
https://chatgpt.com/codex/tasks/task_e_6859f6cc1c2c8331ba1af1dfb1cc4ad4