### PR TITLE
Fix ARM assembly examples

### DIFF
--- a/arm/7seg.s
+++ b/arm/7seg.s
@@ -1,0 +1,24 @@
+// Jacob Panov
+
+// Return segment pattern for a single hex digit.
+
+.global _start
+_start:
+    ldr r0, =8
+    bl sevenseg
+    1: b 1b
+
+.global sevenseg
+sevenseg:
+    cmp r0, #15
+    bhi invalid
+    adr r1, SegTable
+    ldrb r0, [r1, r0]
+    bx lr
+invalid:
+    mov r0, #0
+    bx lr
+
+SegTable:
+    .byte 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07
+    .byte 0x7f,0x6f,0x77,0x7c,0x39,0x5e,0x79,0x71

--- a/arm/7seg8.s
+++ b/arm/7seg8.s
@@ -1,0 +1,49 @@
+// Jacob Panov
+
+// Display 32-bit number on 8 seven-seg digits.
+
+.global _start
+_start:
+    ldr r0, =8
+    bl hexdisplay
+    1: b 1b
+
+.global hexdisplay
+hexdisplay:
+    push {r4-r7, lr}
+    adr r2, SegTable
+    mov r4, r0          // save input
+    mov r5, #0          // low 32 bits result
+    mov r6, #0          // high 32 bits result
+    mov r7, #0          // shift amount
+
+    // lower four digits
+1:
+    and r3, r4, #0xf
+    ldrb r3, [r2, r3]
+    orr r5, r5, r3, lsl r7
+    lsr r4, r4, #4
+    add r7, r7, #8
+    cmp r7, #32
+    bne 1b
+
+    // upper four digits
+    mov r7, #0
+    mov r4, r0, lsr #16
+2:
+    and r3, r4, #0xf
+    ldrb r3, [r2, r3]
+    orr r6, r6, r3, lsl r7
+    lsr r4, r4, #4
+    add r7, r7, #8
+    cmp r7, #32
+    bne 2b
+
+    mov r0, r5
+    mov r1, r6
+    pop {r4-r7, lr}
+    bx lr
+
+SegTable:
+    .byte 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07
+    .byte 0x7f,0x6f,0x77,0x7c,0x39,0x5e,0x79,0x71

--- a/arm/accum1.s
+++ b/arm/accum1.s
@@ -1,0 +1,42 @@
+// Jacob Panov
+
+// Simple accumulator calculator.
+
+.data
+Cmd: .string "+0+@-P"
+
+.text
+.global _start
+_start:
+    ldr r0, =Cmd
+    bl calc
+    1: b 1b
+
+.global calc
+calc:
+    mov r1, r0    // command pointer
+    mov r0, #0    // accumulator
+loop:
+    ldrb r2, [r1], #1
+    cmp r2, #0
+    beq done
+    ldrsb r3, [r1], #1
+    cmp r2, #'+'
+    beq add
+    cmp r2, #'-'
+    beq sub
+    cmp r2, #'*'
+    beq mul
+    b loop
+add:
+    add r0, r0, r3
+    b loop
+sub:
+    sub r0, r0, r3
+    b loop
+mul:
+    mul r2, r0, r3
+    mov r0, r2
+    b loop
+done:
+    bx lr

--- a/arm/accum2.s
+++ b/arm/accum2.s
@@ -1,0 +1,59 @@
+// Jacob Panov
+
+// Accumulator with conditional branches.
+
+.data
+Cmd:  .byte '+', 1, 'B', 1, '+', 2, '+', 3, 0
+Cmd2: .byte '+', 1, 'b', 1, '+', 2, '+', 3, 0
+
+.text
+.global _start
+_start:
+    ldr r0, =Cmd
+    bl calc
+    1: b 1b
+
+.global calc
+calc:
+    mov r1, r0
+    mov r0, #0
+loop:
+    ldrb r2, [r1], #1
+    cmp r2, #0
+    beq done
+    ldrsb r3, [r1], #1
+    cmp r2, #'+'
+    beq add
+    cmp r2, #'-'
+    beq sub
+    cmp r2, #'*'
+    beq mul
+    cmp r2, #'b'
+    beq bneg
+    cmp r2, #'B'
+    beq bpos
+    b loop
+add:
+    add r0, r0, r3
+    b loop
+sub:
+    sub r0, r0, r3
+    b loop
+mul:
+    mul r2, r0, r3
+    mov r0, r2
+    b loop
+bneg:
+    cmp r0, #0
+    bge loop
+    mov r4, r3, lsl #1
+    add r1, r1, r4
+    b loop
+bpos:
+    cmp r0, #0
+    blt loop
+    mov r4, r3, lsl #1
+    add r1, r1, r4
+    b loop
+done:
+    bx lr

--- a/arm/arraysum.s
+++ b/arm/arraysum.s
@@ -1,0 +1,25 @@
+// Jacob Panov
+
+// Sum elements of array.
+
+.data
+Array: .word 1, 2, 3
+
+.text
+.global _start
+_start:
+    ldr r0, =Array
+    ldr r1, =3
+    bl arraysum
+    b _start
+
+// Sum elements of array
+arraysum:
+    mov r2, #0
+1:
+    ldr r3, [r0], #4
+    add r2, r2, r3
+    subs r1, r1, #1
+    bne 1b
+    mov r0, r2
+    bx lr

--- a/arm/bcd2.s
+++ b/arm/bcd2.s
@@ -1,0 +1,18 @@
+// Jacob Panov
+
+// Convert number 0-15 to BCD representation.
+
+.global _start
+_start:
+    ldr r0, =10
+    bl bcd
+    b _start
+
+// Convert a number to BCD
+bcd:
+    cmp r0, #10
+    movlt r1, #0
+    movge r1, #1
+    subge r0, r0, #10
+    orr r0, r0, r1, lsl #4
+    bx lr

--- a/arm/decstr1.s
+++ b/arm/decstr1.s
@@ -1,0 +1,29 @@
+// Jacob Panov
+
+// Convert unsigned decimal string to integer.
+
+.data
+Str: .string "1234"
+
+.text
+.global _start
+_start:
+    ldr r0, =Str
+    bl decstr
+    b _start
+
+.global decstr
+decstr:
+    mov r1, r0    // pointer
+    mov r0, #0    // result
+1:
+    ldrb r2, [r1], #1
+    cmp r2, #0
+    beq done
+    sub r2, r2, #'0'
+    mov r3, r0, lsl #3
+    add r3, r3, r0, lsl #1
+    add r0, r3, r2
+    b 1b
+done:
+    bx lr

--- a/arm/decstr2.s
+++ b/arm/decstr2.s
@@ -1,0 +1,40 @@
+// Jacob Panov
+
+// Parse signed decimal string.
+
+.data
+Str: .string "1234"
+
+.text
+.global _start
+_start:
+    ldr r0, =Str
+    bl decstr
+    b _start
+
+.global decstr
+decstr:
+    mov r1, r0    // pointer
+    ldrb r2, [r1], #1
+    mov r3, #0    // negative flag
+    cmp r2, #'-'
+    bne first
+    mov r3, #1
+    ldrb r2, [r1], #1
+first:
+    mov r0, #0
+loop:
+    cmp r2, #0
+    beq finish
+    sub r2, r2, #'0'
+    mov r4, r0, lsl #3
+    add r4, r4, r0, lsl #1
+    add r0, r4, r2
+    ldrb r2, [r1], #1
+    b loop
+finish:
+    cmp r3, #0
+    beq done
+    rsb r0, r0, #0
+done:
+    bx lr

--- a/arm/fib3.s
+++ b/arm/fib3.s
@@ -1,0 +1,29 @@
+// Jacob Panov
+
+// Compute call count for recursive fib.
+
+.global _start
+_start:
+    mov r0, #4
+    bl numfib
+    1: b 1b
+
+.global numfib
+numfib:
+    cmp r0, #1
+    bhi rec
+    mov r0, #1
+    bx lr
+rec:
+    // save registers we'll use
+    push {r4, r5, lr}
+    mov r4, r0        // n
+    sub r0, r4, #1
+    bl numfib         // numfib(n-1)
+    mov r5, r0        // save result of first call
+    sub r0, r4, #2
+    bl numfib         // numfib(n-2)
+    add r0, r0, r5
+    add r0, r0, #1    // count this call
+    pop {r4, r5, lr}
+    bx lr

--- a/arm/hailstone.s
+++ b/arm/hailstone.s
@@ -1,0 +1,31 @@
+// Jacob Panov
+
+// Count steps for hailstone sequence to reach 1.
+
+.global _start
+_start:
+    mov r0, #5
+    bl hailstone
+    1: b 1b
+
+.global hailstone
+hailstone:
+    // r0 = starting number (>0)
+    mov r1, r0      // current value
+    mov r0, #0      // step counter
+1:
+    cmp r1, #1
+    beq hs_done
+    tst r1, #1
+    beq even
+    // odd: r1 = 3*r1 + 1
+    add r1, r1, r1, lsl #1
+    add r1, r1, #1
+    b step
+even:
+    mov r1, r1, lsr #1
+step:
+    add r0, r0, #1
+    b 1b
+hs_done:
+    bx lr

--- a/arm/hex1.s
+++ b/arm/hex1.s
@@ -1,0 +1,19 @@
+// Jacob Panov
+
+// Convert a single hex digit (0..15) to ASCII.
+
+.global _start
+_start:
+    ldr r0, =0xa
+    bl hex1
+    b _start
+
+// Print one hex digit
+hex1:
+    cmp r0, #9
+    ble digit
+    add r0, r0, #'a' - 10
+    bx lr
+digit:
+    add r0, r0, #'0'
+    bx lr

--- a/arm/hexstr.s
+++ b/arm/hexstr.s
@@ -1,0 +1,47 @@
+// Jacob Panov
+
+// Convert a 32-bit number to a hex string without leading zeros.
+
+.data
+MyString: .skip 12
+
+.text
+.global _start
+_start:
+    ldr r0, =MyString
+    ldr r1, =0x12345678
+    bl hexstr
+    b _start
+
+// Convert number to string
+hexstr:
+    push {r4-r7, lr}
+    mov r4, r0      // destination pointer
+    mov r5, r1      // number
+    mov r6, #28     // bit index
+    mov r7, #0      // started flag
+1:
+    mov r2, r5, lsr r6
+    and r2, r2, #0xf
+    cmp r7, #0
+    bne store
+    cmp r2, #0
+    beq skip
+store:
+    mov r7, #1
+    cmp r2, #9
+    addle r2, r2, #'0'
+    addgt r2, r2, #'a'-10
+    strb r2, [r4], #1
+skip:
+    subs r6, r6, #4
+    bge 1b
+    cmp r7, #0
+    bne finish
+    mov r2, #'0'
+    strb r2, [r4], #1
+finish:
+    mov r2, #0
+    strb r2, [r4]
+    pop {r4-r7, lr}
+    bx lr

--- a/arm/manhattan.s
+++ b/arm/manhattan.s
@@ -1,0 +1,64 @@
+// Jacob Panov
+
+// Manhattan distance to nearest subway station.
+
+.data
+Map: .byte 1, 0, 0, 1, 0
+
+.text
+.global _start
+_start:
+    ldr r0, =5
+    ldr r1, =1
+    ldr r2, =Map
+    bl manhattan
+    1: b 1b
+
+.global manhattan
+manhattan:
+    push {r4-r11, lr}
+    mov r4, r0      // width
+    mov r5, r1      // height
+    mov r6, r2      // map pointer
+    mov r7, r4, asr #1  // center x
+    mov r8, r5, asr #1  // center y
+    mov r0, #-1     // result
+    mov r9, #0      // found flag
+    mov r10, #0     // y index
+    mov r11, r6     // pointer
+outer_y:
+    cmp r10, r5
+    bge finish
+    mov r1, #0      // x index
+inner_x:
+    cmp r1, r4
+    bge next_row
+    ldrb r2, [r11], #1
+    cmp r2, #0
+    beq skip
+    subs r2, r1, r7
+    rsbmi r2, r2, #0
+    subs r3, r10, r8
+    rsbmi r3, r3, #0
+    add r2, r2, r3
+    cmp r9, #0
+    bne compare
+    mov r0, r2
+    mov r9, #1
+    b skip
+compare:
+    cmp r2, r0
+    movlt r0, r2
+skip:
+    add r1, r1, #1
+    b inner_x
+next_row:
+    add r10, r10, #1
+    b outer_y
+finish:
+    cmp r9, #0
+    bne done
+    mov r0, #-1
+done:
+    pop {r4-r11, lr}
+    bx lr

--- a/arm/memmove.s
+++ b/arm/memmove.s
@@ -1,0 +1,51 @@
+// Jacob Panov
+
+// Memory copy that handles overlapping regions.
+
+.data
+.word 0x9999
+Dest: .word 0, 0, 0, 0, 0xaaaa
+Src:  .word 1, 2, 3, 4, 0xbbbb
+
+.text
+.global _start
+_start:
+    ldr r0, =Dest
+    ldr r1, =Src
+    ldr r2, =16
+    bl memmove
+    1: b 1b
+
+.global memmove
+memmove:
+    push {r4-r5, lr}
+    cmp r2, #0
+    beq finish
+    cmp r0, r1
+    beq finish
+    mov r3, r0          // save dest pointer
+    add r4, r1, r2      // end of source
+    cmp r0, r1
+    blt forward_copy
+    cmp r0, r4
+    bge forward_copy
+    // overlapping copy backward
+    add r1, r1, r2
+    add r0, r0, r2
+1:
+    subs r2, r2, #1
+    ldrb r5, [r1, #-1]!
+    strb r5, [r0, #-1]!
+    bne 1b
+    mov r0, r3
+    b finish
+forward_copy:
+1:
+    ldrb r5, [r1], #1
+    strb r5, [r0], #1
+    subs r2, r2, #1
+    bne 1b
+    mov r0, r3
+finish:
+    pop {r4-r5, lr}
+    bx lr

--- a/arm/normalize.s
+++ b/arm/normalize.s
@@ -1,0 +1,59 @@
+// Jacob Panov
+
+// Normalize array of U32 samples to U16 range.
+
+.data
+Input: .word 0x10000, 0x20000, 0x80000, 0x4000
+Output: .skip 8
+
+.text
+.global _start
+_start:
+    ldr r0, =4
+    ldr r1, =Input
+    ldr r2, =Output
+    bl normalize
+    b _start
+
+// Normalize to U16
+normalize:
+    push {r4-r8, lr}
+    mov r4, #0          // current max
+    mov r5, r0          // count
+    mov r6, r1          // input ptr
+1:
+    ldr r7, [r6], #4
+    cmp r7, r4
+    movhi r4, r7
+    subs r5, r5, #1
+    bne 1b
+
+    clz r5, r4
+    rsb r5, r5, #32
+    subs r5, r5, #1
+    rsb r5, r5, #15     // shift amount (positive=left, negative=right)
+
+    mov r6, r1          // reset input
+    mov r7, r2          // output
+    mov r8, r0          // counter
+    cmp r5, #0
+    bge left
+    rsb r5, r5, #0      // r5 = -shift
+right_loop:
+    ldr r4, [r6], #4
+    mov r4, r4, lsr r5
+    strh r4, [r7], #2
+    subs r8, r8, #1
+    bne right_loop
+    b done
+left:
+left_loop:
+    ldr r4, [r6], #4
+    mov r4, r4, lsl r5
+    strh r4, [r7], #2
+    subs r8, r8, #1
+    bne left_loop
+
+done:
+    pop {r4-r8, lr}
+    bx lr

--- a/arm/random.s
+++ b/arm/random.s
@@ -1,0 +1,29 @@
+// Jacob Panov
+
+// Returns the n-th value of a linear congruential generator.
+
+.global _start
+_start:
+    ldr r0, =2    // Example: compute 2nd number
+    bl random
+    1: b 1b    // Done
+
+.global random
+random:
+    // r0 = n
+    mov r1, #0          // current value (seed)
+    cmp r0, #0
+    beq rand_done
+
+    ldr r2, =134775813  // multiplier
+    mov r3, #1          // increment
+    mov r4, #0          // temp
+1:
+    mul r4, r1, r2      // r4 = value * multiplier
+    add r1, r4, r3      // value += increment
+    subs r0, r0, #1
+    bne 1b
+
+rand_done:
+    mov r0, r1
+    bx lr

--- a/arm/subarraysum.s
+++ b/arm/subarraysum.s
@@ -1,0 +1,40 @@
+// Jacob Panov
+
+// Maximum subarray sum (O(n^2) solution).
+
+.data
+Array: .word -1, -1, 3, -1, 3, -2
+
+.text
+.global _start
+_start:
+    ldr r0, =Array
+    ldr r1, =6
+    bl subarraysum
+    b _start
+
+// Sum elements of array
+subarraysum:
+    push {r4-r8, lr}
+    mov r4, r0      // base pointer
+    mov r5, r1      // length
+    ldr r0, [r4]    // max_sum
+    mov r6, #0      // outer index
+outer_loop:
+    mov r7, #0      // current sum
+    mov r8, r4
+    add r8, r8, r6, lsl #2
+    mov r3, r5
+    sub r3, r3, r6
+inner_loop:
+    ldr r2, [r8], #4
+    add r7, r7, r2
+    cmp r7, r0
+    movgt r0, r7
+    subs r3, r3, #1
+    bne inner_loop
+    add r6, r6, #1
+    cmp r6, r5
+    blt outer_loop
+    pop {r4-r8, lr}
+    bx lr


### PR DESCRIPTION
Summary
- refine 7seg for invalid inputs
- preserve registers and return path in memmove

Testing
- `for f in arm/7seg.s arm/7seg8.s arm/memmove.s arm/fib3.s; do echo compiling $f; arm-none-eabi-as $f -o /tmp/temp.o || break; done`