### PR TITLE
Complete ARM memory helper problems

### DIFF
--- a/arm/memaddr.s
+++ b/arm/memaddr.s
@@ -10,3 +10,7 @@ _start:
 1:      b 1b    // Done
 
 addrlines:
+    sub r2, r0, #1       // Depth - 1
+    clz r2, r2           // Count leading zeros
+    rsb r0, r2, #32      // 32 - leading zeros
+    bx lr

--- a/arm/memenable.s
+++ b/arm/memenable.s
@@ -9,3 +9,9 @@ _start:
 1:      b 1b    // Done
 
 memenable:
+    lsr r1, r0, #12        // Check upper 20 bits
+    ldr r2, =0xff3
+    cmp r1, r2
+    moveq r0, #1
+    movne r0, #0
+    bx lr

--- a/arm/memenable2.s
+++ b/arm/memenable2.s
@@ -9,3 +9,11 @@ _start:
 1:      b 1b    // Done
 
 memenable:
+    mov r3, r0            // Preserve address
+    lsr r1, r3, #12       // Check range 0xff3000-0xff3fff
+    ldr r2, =0xff3
+    cmp r1, r2
+    mvnne r0, #0          // Return -1 if outside range
+    lsreq r0, r3, #8      // Device index bits [11:8]
+    andeq r0, r0, #0xf
+    bx lr

--- a/arm/memsize.s
+++ b/arm/memsize.s
@@ -10,3 +10,7 @@ _start:
 1:      b 1b    // Done
 
 memsize:
+    mov r2, #1           // 1 << address lines
+    lsl r2, r2, r0
+    mul r0, r2, r1       // capacity in bits
+    bx lr


### PR DESCRIPTION
- addrlines: compute address line count using `clz`
- memsize: compute memory capacity in bits
- memenable: check chip enable range
- memenable2: return which 256‑byte device to enable

